### PR TITLE
Move the definition of MLS AppSync to its own spec

### DIFF
--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -174,10 +174,10 @@ The protocol layering of the MIMI transport protocol is as follows:
 ~~~
 {: #fig-layers title="MIMI protocol layering" }
 
-MIMI uses MLS {{!RFC9420}} for end-to-end security, using the MLS AppSync
-proposal type to efficiently synchronize room state across the clients involved
-in a room. The MIMI transport is based on HTTPS over mutually-authenticated
-TLS.
+MIMI uses MLS for end-to-end security, using the MLS AppSync proposal type to
+efficiently synchronize room state across the clients involved in a room
+{{!RFC9420}} {{!I-D.barnes-mls-appsync}}. The MIMI transport is based on HTTPS
+over mutually-authenticated TLS.
 
 # Example protocol flow
 
@@ -1520,156 +1520,6 @@ participant belonging to a follower server leaves the room, the certificate of
 that user MUST be removed from the list. Changes to the `external_senders`
 extension only take effect when the MLS proposal containing the event is
 committed by a MIMI commit.
-
-
-# MLS Application State Synchronization
-
-**TODO:** This section should be moved to its own document in the MLS working group.
-
-One of the primary security benefits of MLS is that the MLS key schedule
-confirms that the group agrees on certain metadata, such as the membership of
-the group. Members that disagree on the relevant metadata will arrive at
-different keys and be unable to communicate. Applications based on MLS can
-integrate their state into this metadata in order to confirm that the members of
-an MLS group agree on application state as well as MLS metadata.
-
-Here, we define two extensions to MLS to facilitate this application design:
-
-1. A GroupContext extension `application_states` that confirms agreement on
-   application state from potentially multiple sources.
-2. A new proposal type AppSync that allows MLS group members to propose changes
-   to the agreed application state.
-
-The `application_states` extension allows the application to inject state
-objects into the MLS key schedule. Changes to this state can be made out of
-band, or using the AppSync proposal. Using the AppSync proposal ensures that
-members of the MLS group have received the relevant state changes before they
-are reflected in the group's `application_states`.
-
-> **NOTE:** This design exposes the high-level structure of the application state
-> to MLS.  An alternative design would be to have the application state be opaque
-> to MLS.  There is a trade-off between generality and the complexity of the API
-> between the MLS implementation and the application.  An opaque design would give
-> the application more freedom, but require the MLS stack to call out to the
-> application to get the updated state as part of Commit processing.  This design
-> allows the updates to happen within the MLS stack, so that no callback is
-> needed, at the cost of forcing the application state to fit a certain structure.
-> It also potentially can result in smaller state updates in large groups.
-
-The state for Each `applicationId` in the `application_states` needs to conform
-to one of four basic types: an ordered array, an unordered array, a map, or an
-irreducible blob. This allows the AppSync proposal to efficiently modify a large
-application state object.
-
-The content of the `application_states` extension and the `AppSync` proposal are
-structured as follows:
-
-~~~ tls
-enum {
-    irreducible(0),
-    map(1),
-    unorderedList(2),
-    orderedArray(3),
-    (255)
-} StateType;
-
-struct {
-  opaque element<V>;
-} OpaqueElement;
-
-struct {
-  opaque elementName<V>;
-  opaque elementValue<V>;
-} OpaqueMapElement;
-
-struct {
-  uint32 applicationId;
-  StateType stateType;
-  select (stateType) {
-    case irreducible:
-      OpaqueElement state;
-    case map:
-      OpaqueMapElement mapEntries<V>;
-    case unorderedList:
-      OpaqueElement unorderedEntries<V>;
-    case orderedArray:
-      OpaqueElement orderedEntries<V>;
-  };
-} ApplicationState;
-
-struct {
-  ApplicationState applicationStates<V>;
-} ApplicationStatesExtension;
-~~~
-{: #fig-app-state title="The `application_state` extension" }
-
-~~~ tls
-struct {
-  uint32 index;
-  opaque element<V>;
-} ElementWithIndex;
-
-
-struct {
-  uint32 applicationId;
-  StateType stateType;
-  select (stateType) {
-    case irreducible:
-      OpaqueElement newState;
-    case map:
-      OpaqueElement removedKeys<V>;
-      OpaqueMapElement newOrUpdatedElements<V>;
-    case unorderedList:
-      uint32 removedIndices<V>;
-      OpaqueElement addedEntries<V>;
-    case orderedArray:
-      ElementWithIndex replacedElements<V>;
-      uint32 removedIndices<V>;
-      ElementWithIndex insertedElements<V>;
-      OpaqueElement appenededEntries<V>;
-  };
-} AppSync;
-~~~
-{: #fig-app-sync title="The AppSync proposal type" }
-
-The `applicationId` determines the structure and interpretation of the contents.
-of an ApplicationState object. AppSync proposals
-contain changes to this state, which the client uses to update the
-representation of the state in `application_states`.
-
-A client receiving an AppSync proposal applies it in the following way:
-
-* Identify an `application_states` GroupContext extension which contains the
-  same `application_id` state as the AppSync proposal
-* Apply the relevant operations (replace, remove, update, append, insert)
-  according to the `stateType` to the relevant parts of the ApplicationState
-  object in `application_states` extension.
-
-An AppSync for an irreducible state replaces its `state` element with a new
-(possibly empty) `newState`. An AppSync for a map-based ApplicationState first
-removes all the keys in `removedKeys` and than replaces or adds the elements in
-`newOrUpdatedElements`. An AppSync for an unorderedList ApplicationState first
-removes all the indexes in `removedIndices`, then adds the elements in
-`addedEntries`. Finally an AppSync for an orderedArray, replaces all the
-elements (index-by-index) in `replacedElements`, the removes the elements in
-`removedIndices` according to the then order of the array, then inserts all the
-elements in `insertedElements` according to the then order of the array, then
-finally appends the `appendedEntries` (in order). All indices are zero-based.
-
-Note that the `application_states` extension is updated directly by AppSync
-proposals; a GroupContextExtensions proposal is not necessary. A proposal list
-that contains both an AppSync proposal and a GroupContextExtensions proposal
-is invalid.
-
-Likewise a proposal list in a Commit MAY contain more than one AppSync proposal,
-but no more than one AppSync proposal per `applicationId`. The proposals are
-applied in the order that they are sent in the Commit.
-
-AppSync proposals do not need to contain an UpdatePath. An AppSync proposal can
-be sent by an authorized external sender.
-
-> **TODO:** IANA registry for `application_id`; register extension and proposal types
->as safe extensions
 
 # Consent
 

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -590,7 +590,7 @@ Every application message sent within a room is authenticated and confidentialit
 by virtue of being encapsulated in an MLS PrivateMessage object.
 
 MIMI uses the MLS application state synchronization mechanism
-({{mls-application-state-synchronization}}) to ensure that the clients involved
+({{I-D.barnes-mls-appsync}}) to ensure that the clients involved
 in a MIMI room agree on the state of the room.  Each MIMI message that changes
 the state of the room is encapsulated in an AppSync proposal and transmitted
 inside an MLS PublicMessage object.


### PR DESCRIPTION
Rohan and I separately published [draft-barnes-mls-appsync](https://datatracker.ietf.org/doc/draft-barnes-mls-appsync/), which is currently just a copy/paste of the content from this document.  No technical changes, just moving things around.