### PR TITLE
Allow searches for multiple fields

### DIFF
--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1723,15 +1723,13 @@ format of a telephone number with the "+" prefix matches exactly (for example:
 of any field which contains the name of a (usually human) user. For example,
 `mat` would match first (given) or middle names Matt, Matthew, Mathias, or
 Mathieu and last (family) names of Mather and Matali. `wholeProfile` means that
-the query string matches a case-insensitive substring of any searchable field in
+the query string matches a substring of any searchable field in
 a user's profile.
 
 `oidcStdClaim` means that the query string exactly matches the specified
 UserInfo Standard Claim (defined in Section 5.1 of {{OidcCore}}).
 `vcardField` means that the query string exactly matches the specified vCard
 property listed in the vCard Properties IANA registry.
-
-> **TODO**: Add language about case sensitivity for some other identifier types.
 
 As noted above, searches only return results for a user when the fields searched
 are searchable according the user's and provider's search policies.

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1696,13 +1696,13 @@ enum {
 
 struct {
   SearchIdentifierType searchType;
-  opaque searchValue<V>;  /* a UTF8 string */
   select(type) {
     case oidcStdClaim:
       opaque claimName<V>;
     case vcardField:
       opaque propertyName<V>;
   };
+  opaque searchValue<V>;  /* a UTF8 string */
 } QueryElement;
 
 struct {

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1675,10 +1675,10 @@ send a join link out-of-band to Alice for her to join a room of Zach's
 choosing.
 
 The request body is described as below. Each request can contain multiple
-query elements, which all have to match for the request to match. For
-example matching both the OpenID Connect (OIDC) {{OidcCore}} `given_name` and
-`family_name`, or matching the OIDC `given_name` and the organization (from
-the vCard {{!RFC6350}} ORG property).
+query elements, which all have to match for the request to match (AND
+semantics). For example matching both the OpenID Connect (OIDC) {{OidcCore}}
+`given_name` and `family_name`, or matching the OIDC `given_name` and the
+organization (from the vCard {{!RFC6350}} ORG property).
 
 ~~~ tls
 enum {


### PR DESCRIPTION
- Allow searches for multiple fields (with AND semantics)
- Clarify the semantics of SearchIdentifierType enum

Partially addresses Issue #91 
