### PR TITLE
Fix type of encrypted_groupinfo_and_tree

### DIFF
--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1491,7 +1491,7 @@ struct {
       CipherSuite cipher_suite;
       opaque room_id<V>;
       ExternalSender hub_sender;
-      opaque encrypted_groupinfo_and_tree<V>;
+      HPKECiphertext encrypted_groupinfo_and_tree<V>;
   };
 } GroupInfoResponseTBS;
 


### PR DESCRIPTION
was `opaque`, should have been `HPKECiphertext`.