### PR TITLE
Fix inconsistencies in GroupInfoResponse

### DIFF
--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1494,11 +1494,11 @@ encrypted_groupinfo_and_tree = EncryptWithLabel(
 
 struct {
   Protocol version;
+  opaque room_id<V>;
   GroupInfoCode status;
   select (protocol) {
     case mls10:
       CipherSuite cipher_suite;
-      opaque room_id<V>;
       ExternalSender hub_sender;
       HPKECiphertext encrypted_groupinfo_and_tree<V>;
   };
@@ -1506,16 +1506,19 @@ struct {
 
 struct {
   Protocol version;
+  opaque room_id<V>;
   GroupInfoCode status;
-  select (protocol) {
-    case mls10:
-      CipherSuite cipher_suite;
-      opaque room_id<V>;
-      ExternalSender hub_sender;
-      opaque encrypted_groupinfo_and_tree<V>;
-      /* TODO: add appropriate key for Hub to sign with */
-      /* SignWithLabel(., "GroupInfoResponseTBS", GroupInfoResponseTBS) */
-      opaque signature<V>;
+  select (status) {
+    case (success):
+      select (protocol) {
+        case mls10:
+          CipherSuite cipher_suite;
+          ExternalSender hub_sender;
+          HPKECiphertext encrypted_groupinfo_and_tree<V>;
+          /* SignWithLabel(hub_sender, "GroupInfoResponseTBS", */
+          /*                GroupInfoResponseTBS) */
+          opaque signature<V>;
+      };
   };
 } GroupInfoResponse;
 ~~~

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1500,7 +1500,7 @@ struct {
     case mls10:
       CipherSuite cipher_suite;
       ExternalSender hub_sender;
-      HPKECiphertext encrypted_groupinfo_and_tree<V>;
+      HPKECiphertext encrypted_groupinfo_and_tree;
   };
 } GroupInfoResponseTBS;
 
@@ -1514,7 +1514,7 @@ struct {
         case mls10:
           CipherSuite cipher_suite;
           ExternalSender hub_sender;
-          HPKECiphertext encrypted_groupinfo_and_tree<V>;
+          HPKECiphertext encrypted_groupinfo_and_tree;
           /* SignWithLabel(hub_sender, "GroupInfoResponseTBS", */
           /*                GroupInfoResponseTBS) */
           opaque signature<V>;

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1509,7 +1509,7 @@ struct {
   opaque room_id<V>;
   GroupInfoCode status;
   select (status) {
-    case (success):
+    case success:
       select (protocol) {
         case mls10:
           CipherSuite cipher_suite;
@@ -1519,6 +1519,7 @@ struct {
           /*                GroupInfoResponseTBS) */
           opaque signature<V>;
       };
+  default: struct{};
   };
 } GroupInfoResponse;
 ~~~


### PR DESCRIPTION
- Fix inconsistencies in GroupInfoResponse
- In error response cases, don't require the MLS payload